### PR TITLE
Drop libsecret module

### DIFF
--- a/com.cloudchewie.cloudotp.yaml
+++ b/com.cloudchewie.cloudotp.yaml
@@ -26,7 +26,6 @@ cleanup:
   - /share/gtk-doc
   - /var/lib
 modules:
-  - shared-modules/libsecret/libsecret.json
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
   - name: keybinder3
     buildsystem: autotools

--- a/flatpak-flutter.yaml
+++ b/flatpak-flutter.yaml
@@ -24,8 +24,6 @@ cleanup:
   - /share/gtk-doc
   - /var/lib
 modules:
-  - shared-modules/libsecret/libsecret.json
-
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
 
   - name: keybinder3


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides libsecret; therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes: https://github.com/flathub/com.cloudchewie.cloudotp/issues/31